### PR TITLE
Default for log4jcomments, RollingFileAppender attributes case-insensitive

### DIFF
--- a/src/main/java/farnetto/log4jconverter/Converter.java
+++ b/src/main/java/farnetto/log4jconverter/Converter.java
@@ -96,6 +96,7 @@ public class Converter
         }
 
         Map<String,String> comments = parseComments(log4jInput);
+        comments.putIfAbsent("log4jconfiguration", "");
 
         LOG.debug(comments);
 

--- a/src/main/resources/farnetto/log4jconverter/template/log4j2.ftl
+++ b/src/main/resources/farnetto/log4jconverter/template/log4j2.ftl
@@ -7,10 +7,10 @@ ${comments.log4jconfiguration}
       <#list appenders as appender>
         ${comments[appender.name]!}
         <#list appender.param as param>
-          <#if param.name == "File">
+          <#if param.name?matches("file", "i") >
             <#assign fileName=param.value>
           </#if>
-          <#if param.name == "Append">
+          <#if param.name?matches("append", "i") >
             <#assign append=param.value>
           </#if>
         </#list>


### PR DESCRIPTION
In our input `log4j.xml` comments were missing completely, which resulted in failing conversion because of a missing value in the Map.

Furthermore the attributes `file` and `append` were lowercase, resulting in another failing conversion.